### PR TITLE
Fix Dirty background-image shown on resizable element

### DIFF
--- a/resource-server-content/src/main/webapp/rs/jqueryui/1.8.13/theme/smoothness/jquery-ui-1.8.13-smoothness.css
+++ b/resource-server-content/src/main/webapp/rs/jqueryui/1.8.13/theme/smoothness/jquery-ui-1.8.13-smoothness.css
@@ -306,7 +306,7 @@
 	/* http://bugs.jqueryui.com/ticket/7233
 	 - Resizable: resizable handles fail to work in IE if transparent and content overlaps
 	*/
-	background-image:url(data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=);
+	background-image:url(data:'');
 }
 .ui-resizable-disabled .ui-resizable-handle, .ui-resizable-autohide .ui-resizable-handle { display: none; }
 .ui-resizable-n { cursor: n-resize; height: 7px; width: 100%; top: -5px; left: 0; }


### PR DESCRIPTION
IE and firefox (26) show a dirty background-image, see on http://bugs.jqueryui.com/ticket/7233

In version 1.9 of jquery this background-image is removed.
