### PR TITLE
NOJIRA: Bad path for LOG_DIR

### DIFF
--- a/resource-server-webapp/src/main/resources/logback.xml
+++ b/resource-server-webapp/src/main/resources/logback.xml
@@ -62,7 +62,7 @@
     <!--
      | Specify a local property that sets up the logging directory
      +-->
-    <property scope="local" name="LOG_DIR" value="${resource-server.webapp.root}/../../logs" />
+    <property scope="local" name="LOG_DIR" value="${catalina.base}/logs" />
 
     <!--
      | Setup a file based logger that rolls


### PR DESCRIPTION
Using a Catalina Path would be better than a path like ${resource-server.webapp.root}/../../logs wich will depend on where you deploy.

In my case I'm deploying apps on /opt/webapps whereas my tomcat base is on /opt/tomcat, which is an easy to use when you have to update your tomcat version...

More this is a problem when you are deploying the portal and that you can't change this path from the deploy-ear target.
