### PR TITLE
build(maven): allow maven release plugin to push release changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,6 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <localCheckout>true</localCheckout>
                         <tagNameFormat>resource-server-@{project.version}</tagNameFormat>
-                        <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
This speeds up the release process by removing the push branch and push tag steps.
While also reducing the chance that a release could be but never tagged and pushed.