### PR TITLE
ci: run tests using the package lifecycle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ matrix:
       osx_image: xcode8.3
 
 script:
-  - mvn test --batch-mode
+  - mvn package --batch-mode
   - mvn checkstyle:check --batch-mode --fail-never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
 build_script:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 test_script:
-  - mvn test --batch-mode
+  - mvn package --batch-mode
   - mvn checkstyle:check --batch-mode --fail-never
 cache:
   - C:\Users\appveyor\.m2\ -> pom.xml


### PR DESCRIPTION
The jarjar plugin which has been causing issues on CI is attached to the `package` phase.
When `test` is called on CI the `package` phase is not run, causing the generated jar to not exist, resulting in `test` failure.
This moves to using the `package` phase, which calls `test` as a byproduct.