### PR TITLE
docs(readme): add maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Resource Server
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jasig.resourceserver/resource-server-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jasig.resourceserver/resource-server-parent)
 [![Linux Build Status](https://travis-ci.org/Jasig/resource-server.svg?branch=master)](https://travis-ci.org/Jasig/resource-server)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/u60a82l41asrqpp1/branch/master?svg=true)](https://ci.appveyor.com/project/ChristianMurphy/resource-server/branch/master)
 


### PR DESCRIPTION
Give at-a-glance knowledge of:
* latest version number
* that this is available from maven central
* link to documentation on inclusion for maven, gradle, etc