### PR TITLE
feat: Enabled resourceChain for the webjars handler

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -25,6 +25,8 @@ This project includes:
  
   AOP alliance under Public Domain
   Apache Commons Codec under Apache License, Version 2.0
+  Apache Commons Compress under The Apache Software License, Version 2.0
+  Apache Commons Lang under Apache License, Version 2.0
   Apache Log4j API under Apache License, Version 2.0
   Apache Log4j to SLF4J Adapter under Apache License, Version 2.0
   ASM based accessors helper used by json-smart under The Apache Software License, Version 2.0
@@ -121,6 +123,8 @@ This project includes:
   tomcat-embed-core under Apache License, Version 2.0
   tomcat-embed-el under Apache License, Version 2.0
   tomcat-embed-websocket under Apache License, Version 2.0
+  webjars-locator under MIT
+  webjars-locator-core under MIT
   XMLUnit for Java under BSD License
   yui compressor under BSD License
 

--- a/resource-server-webapp/NOTICE
+++ b/resource-server-webapp/NOTICE
@@ -24,6 +24,8 @@ This project includes:
     http://www.famfamfam.com/lab/icons/silk/
  
   Apache Commons Codec under Apache License, Version 2.0
+  Apache Commons Compress under The Apache Software License, Version 2.0
+  Apache Commons Lang under Apache License, Version 2.0
   Apache Log4j API under Apache License, Version 2.0
   Apache Log4j to SLF4J Adapter under Apache License, Version 2.0
   ASM based accessors helper used by json-smart under The Apache Software License, Version 2.0
@@ -93,4 +95,6 @@ This project includes:
   tomcat-embed-core under Apache License, Version 2.0
   tomcat-embed-el under Apache License, Version 2.0
   tomcat-embed-websocket under Apache License, Version 2.0
+  webjars-locator under MIT
+  webjars-locator-core under MIT
 

--- a/resource-server-webapp/pom.xml
+++ b/resource-server-webapp/pom.xml
@@ -69,7 +69,16 @@
 			<artifactId>resource-server-utils</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-	</dependencies>
+        <!--
+         | Allows resources in webjars to be included without their version numbers;
+         | see https://www.webjars.org/documentation#springboot
+         +-->
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>webjars-locator</artifactId>
+            <version>0.34</version>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<finalName>ResourceServingWebapp</finalName>

--- a/resource-server-webapp/src/main/java/org/jasig/portal/resourceserver/WebConfiguration.java
+++ b/resource-server-webapp/src/main/java/org/jasig/portal/resourceserver/WebConfiguration.java
@@ -39,7 +39,8 @@ public class WebConfiguration implements WebMvcConfigurer {
                 .addResourceLocations("/rs/");
         registry
                 .addResourceHandler("/webjars/**")
-                .addResourceLocations("/webjars/");
+                .addResourceLocations("/webjars/")
+                .resourceChain(true);
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Enabled `resourceChain` for the webjars handler. This enables `webjars-locator` to function when present (added to [build.gradle overlays/resource-server/build.gradle](https://github.com/Jasig/uPortal-start/blob/master/overlays/resource-server/build.gradle))

`webjar-locator` allows us to drop the version when sourcing dependencies such as web components
https://www.webjars.org/documentation#springboot

I got the change to make from https://stackoverflow.com/questions/44200423/webjars-locator-doesnt-work-with-xml-based-spring-mvc-4-2-x-configuration

##### Example Use Case
```
<script src="https://unpkg.com/vue@2.5.16"></script>
<script type="text/javascript" src="/resource-server/webjars/uportal__content-carousel/dist/content-carousel.js"></script>
```

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
