### PR TITLE
fix: relpath test correctly handles different OS separator

### DIFF
--- a/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
+++ b/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
@@ -33,8 +33,8 @@ public class RelativePathTest {
     @Test
     public void resolveRelativePath() throws Exception {
         String tempPath = System.getProperty("java.io.tmpdir");
-        if(!tempPath.endsWith("/")) {
-            tempPath += "/";
+        if(!tempPath.endsWith(File.separator)) {
+            tempPath += File.separator;
         }
         
         final File tempDir = new File(new File(tempPath), "relative-path");
@@ -45,6 +45,10 @@ public class RelativePathTest {
         
         final String relativePath = RelativePath.getRelativePath(baseDir, destDir);
         
-        assertEquals("../../e/f", relativePath);
+        final String testPath = ".." + File.separator
+                              + ".." + File.separator
+                              + "e" + File.separator
+                              + "f";
+        assertEquals(testPath, relativePath);
     }
 }

--- a/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
+++ b/resource-server-core/src/test/java/org/jasig/resource/aggr/RelativePathTest.java
@@ -45,10 +45,6 @@ public class RelativePathTest {
         
         final String relativePath = RelativePath.getRelativePath(baseDir, destDir);
         
-        final String testPath = ".." + File.separator
-                              + ".." + File.separator
-                              + "e" + File.separator
-                              + "f";
-        assertEquals(testPath, relativePath);
+        assertEquals("../../e/f", relativePath);
     }
 }


### PR DESCRIPTION
## Summary

The `RelativePathTest.resolveRelativePath` test hardcodes `/` as the path separator, causing it to fail on Windows where the separator is `\`.

Uses `File.separator` instead of hardcoded `/` for both the temp path construction and the expected result assertion.