### PR TITLE
chore: pre-release prep

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -23,30 +23,39 @@ This project includes:
   The famfamfam Silk Icons under the Creative Commons Attribution 3.0 License
     http://www.famfamfam.com/lab/icons/silk/
  
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
-  Apache Commons Lang under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Apache Log4j API under Apache License, Version 2.0
   Apache Log4j to SLF4J Adapter under Apache License, Version 2.0
   asm under BSD-3-Clause
   ASM based accessors helper used by json-smart under The Apache Software License, Version 2.0
   AssertJ fluent assertions under Apache License, Version 2.0
+  bootstrap under MIT
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
   Checker Qual under The MIT License
   ClassGraph under The MIT License (MIT)
   Commons Lang under The Apache Software License, Version 2.0
+  datatables.net under MIT
+  datatables.net-bs5 under MIT
+  datatables.net-searchpanes under MIT
+  datatables.net-searchpanes-bs5 under MIT
+  datatables.net-select under MIT
+  datatables.net-select-bs5 under MIT
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
   error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Expression Language 3.0 API under CDDL + GPLv2 with classpath exception
   FindBugs-jsr305 under The Apache Software License, Version 2.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava ListenableFuture only under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest under BSD License 3
-  Hamcrest Core under BSD License 3
-  J2ObjC Annotations under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  J2ObjC Annotations under Apache License, Version 2.0
   Jackson datatype: jdk8 under The Apache Software License, Version 2.0
   Jackson datatype: JSR310 under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -54,6 +63,7 @@ This project includes:
   jackson-databind under The Apache Software License, Version 2.0
   Jackson-module-parameter-names under The Apache Software License, Version 2.0
   Jakarta Activation under EDL 1.0
+  Jakarta Activation API jar under EDL 1.0
   Jakarta Annotations API under EPL 2.0 or GPL2 w/ CPE
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   Java Servlet API under CDDL + GPLv2 with classpath exception
@@ -62,8 +72,9 @@ This project includes:
   javax.annotation API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  js under Mozilla Public License, Version 1.1
+  jquery under MIT
+  jquery-migrate under MIT
+  jquery-ui under MIT
   JSON library from Android SDK under Apache License 2.0
   JSON Small and Fast Parser under The Apache Software License, Version 2.0
   JSONassert under The Apache Software License, Version 2.0
@@ -80,7 +91,7 @@ This project includes:
   Maven Artifact under Apache License, Version 2.0
   Maven Model under Apache License, Version 2.0
   Maven Plugin API under Apache License, Version 2.0
-  mockito-core under The MIT License
+  mockito-core under MIT
   mockito-junit-jupiter under The MIT License
   Objenesis under Apache License, Version 2.0
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
@@ -91,7 +102,7 @@ This project includes:
   org.xmlunit:xmlunit-core under The Apache Software License, Version 2.0
   Plexus :: Component Annotations under The Apache Software License, Version 2.0
   Plexus Classworlds under Apache License, Version 2.0
-  Plexus Common Utilities under Apache License, Version 2.0
+  Plexus Common Utilities under Apache-2.0
   project ':json-path' under The Apache Software License, Version 2.0
   Resource Server API under Apache License Version 2.0
   Resource Server Content under Apache License Version 2.0
@@ -100,7 +111,7 @@ This project includes:
   Resource Server Plugin under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
   Resource Server Webapp under Apache License, Version 2.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   SnakeYAML under Apache License, Version 2.0
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
@@ -128,5 +139,4 @@ This project includes:
   tomcat-embed-websocket under Apache License, Version 2.0
   webjars-locator-core under MIT
   XMLUnit for Java under BSD License
-  yui compressor under BSD License
 

--- a/pom.xml
+++ b/pom.xml
@@ -290,8 +290,14 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <!--
+            | Artifact was renamed from maven-notice-plugin to notice-maven-plugin.
+            | The old 1.1.0 coordinate depends on javax.xml.bind.JAXBException which
+            | was removed from the JDK in Java 9+, so it fails on Java 11. The new
+            | artifactId inherits v2.0.0 from uportal-portlet-parent.
+          +-->
           <groupId>org.jasig.maven</groupId>
-          <artifactId>maven-notice-plugin</artifactId>
+          <artifactId>notice-maven-plugin</artifactId>
           <configuration>
             <noticeTemplate>NOTICE.template</noticeTemplate>
           </configuration>

--- a/resource-server-api/NOTICE
+++ b/resource-server-api/NOTICE
@@ -23,7 +23,7 @@ This project includes:
   The famfamfam Silk Icons under the Creative Commons Attribution 3.0 License
     http://www.famfamfam.com/lab/icons/silk/
  
-  Apache Commons IO under Apache License, Version 2.0
+  Apache Commons IO under Apache-2.0
   Commons Lang under The Apache Software License, Version 2.0
   Hamcrest Core under New BSD License
   Jakarta Activation under EDL 1.0
@@ -31,13 +31,12 @@ This project includes:
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
   Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
   Resource Server API under Apache License Version 2.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring Commons Logging Bridge under Apache License, Version 2.0
   Spring Core under Apache License, Version 2.0
   XMLUnit for Java under BSD License

--- a/resource-server-api/src/main/binding/bindings.xjb
+++ b/resource-server-api/src/main/binding/bindings.xjb
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Apereo under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Apereo licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License.  You may obtain a
+    copy of the License at the following location:
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <jaxb:bindings
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"

--- a/resource-server-core/NOTICE
+++ b/resource-server-core/NOTICE
@@ -23,26 +23,26 @@ This project includes:
   The famfamfam Silk Icons under the Creative Commons Attribution 3.0 License
     http://www.famfamfam.com/lab/icons/silk/
  
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Commons Lang under The Apache Software License, Version 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Hamcrest Core under New BSD License
   Jakarta Activation under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  js under Mozilla Public License, Version 1.1
   JUnit under Eclipse Public License 1.0
   Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
   Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
   Resource Server API under Apache License Version 2.0
   Resource Server Core under Apache License Version 2.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring Commons Logging Bridge under Apache License, Version 2.0
   Spring Core under Apache License, Version 2.0
   XMLUnit for Java under BSD License
-  yui compressor under BSD License
 

--- a/resource-server-plugin/NOTICE
+++ b/resource-server-plugin/NOTICE
@@ -23,17 +23,18 @@ This project includes:
   The famfamfam Silk Icons under the Creative Commons Attribution 3.0 License
     http://www.famfamfam.com/lab/icons/silk/
  
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
   Apache Commons Lang under Apache License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Jakarta Activation under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   javax.annotation API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   Maven Artifact under Apache License, Version 2.0
   Maven Model under Apache License, Version 2.0
   Maven Plugin API under Apache License, Version 2.0
@@ -42,9 +43,9 @@ This project includes:
   org.eclipse.sisu.plexus under Eclipse Public License, Version 1.0
   Plexus :: Component Annotations under The Apache Software License, Version 2.0
   Plexus Classworlds under Apache License, Version 2.0
-  Plexus Common Utilities under Apache License, Version 2.0
+  Plexus Common Utilities under Apache-2.0
   Resource Server API under Apache License Version 2.0
   Resource Server Core under Apache License Version 2.0
   Resource Server Plugin under Apache License Version 2.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
 

--- a/resource-server-utils/NOTICE
+++ b/resource-server-utils/NOTICE
@@ -23,8 +23,10 @@ This project includes:
   The famfamfam Silk Icons under the Creative Commons Attribution 3.0 License
     http://www.famfamfam.com/lab/icons/silk/
  
-  Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
   Checker Qual under The MIT License
@@ -32,13 +34,14 @@ This project includes:
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
   error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   Expression Language 3.0 API under CDDL + GPLv2 with classpath exception
   FindBugs-jsr305 under The Apache Software License, Version 2.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava ListenableFuture only under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest Core under New BSD License
-  J2ObjC Annotations under The Apache Software License, Version 2.0
+  J2ObjC Annotations under Apache License, Version 2.0
   Jakarta Activation under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   Java Servlet API under CDDL + GPLv2 with classpath exception
@@ -46,17 +49,16 @@ This project includes:
   JavaServer Pages(TM) API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
   Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  mockito-core under The MIT License
+  mockito-core under MIT
   Objenesis under Apache License, Version 2.0
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
   Resource Server API under Apache License Version 2.0
   Resource Server Core under Apache License Version 2.0
   Resource Server Utilities under Apache License Version 2.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
   Spring Commons Logging Bridge under Apache License, Version 2.0

--- a/resource-server-webapp/NOTICE
+++ b/resource-server-webapp/NOTICE
@@ -24,27 +24,37 @@ This project includes:
     http://www.famfamfam.com/lab/icons/silk/
  
   Apache Commons Codec under Apache License, Version 2.0
-  Apache Commons IO under Apache License, Version 2.0
+  Apache Commons Compress under Apache-2.0
+  Apache Commons IO under Apache-2.0
+  Apache Commons Lang under Apache License, Version 2.0
   Apache Log4j API under Apache License, Version 2.0
   Apache Log4j to SLF4J Adapter under Apache License, Version 2.0
   asm under BSD-3-Clause
   ASM based accessors helper used by json-smart under The Apache Software License, Version 2.0
   AssertJ fluent assertions under Apache License, Version 2.0
+  bootstrap under MIT
   Byte Buddy (without dependencies) under Apache License, Version 2.0
   Byte Buddy agent under Apache License, Version 2.0
   Checker Qual under The MIT License
   ClassGraph under The MIT License (MIT)
   Commons Lang under The Apache Software License, Version 2.0
+  datatables.net under MIT
+  datatables.net-bs5 under MIT
+  datatables.net-searchpanes under MIT
+  datatables.net-searchpanes-bs5 under MIT
+  datatables.net-select under MIT
+  datatables.net-select-bs5 under MIT
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
   error-prone annotations under Apache 2.0
+  Esbuild wrapper for Java bundled with original binaries under MIT License
   FindBugs-jsr305 under The Apache Software License, Version 2.0
   Guava InternalFutureFailureAccess and InternalFutures under The Apache Software License, Version 2.0
   Guava ListenableFuture only under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under Apache License, Version 2.0
   Hamcrest under BSD License 3
   Hamcrest Core under BSD License 3
-  J2ObjC Annotations under The Apache Software License, Version 2.0
+  J2ObjC Annotations under Apache License, Version 2.0
   Jackson datatype: jdk8 under The Apache Software License, Version 2.0
   Jackson datatype: JSR310 under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -52,12 +62,15 @@ This project includes:
   jackson-databind under The Apache Software License, Version 2.0
   Jackson-module-parameter-names under The Apache Software License, Version 2.0
   Jakarta Activation under EDL 1.0
+  Jakarta Activation API jar under EDL 1.0
   Jakarta Annotations API under EPL 2.0 or GPL2 w/ CPE
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JAXB2 Basics - Runtime under BSD-Style License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
+  jquery under MIT
+  jquery-migrate under MIT
+  jquery-ui under MIT
   JSON library from Android SDK under Apache License 2.0
   JSON Small and Fast Parser under The Apache Software License, Version 2.0
   JSONassert under The Apache Software License, Version 2.0

--- a/resource-server-webapp/minify.js
+++ b/resource-server-webapp/minify.js
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 const esbuild = require('esbuild');
 const { globSync } = require('glob');
 const path = require('path');

--- a/resource-server-webapp/pom.xml
+++ b/resource-server-webapp/pom.xml
@@ -266,8 +266,9 @@
         </executions>
       </plugin>
       <plugin>
+        <!-- Renamed from maven-notice-plugin to notice-maven-plugin; v2.0.0 inherited from uportal-portlet-parent works on Java 11. -->
         <groupId>org.jasig.maven</groupId>
-        <artifactId>maven-notice-plugin</artifactId>
+        <artifactId>notice-maven-plugin</artifactId>
         <configuration>
           <noticeTemplate>../NOTICE.template</noticeTemplate>
         </configuration>


### PR DESCRIPTION
## Summary

Pre-release housekeeping to unblock the `mvn release:prepare` run.

- Rename `org.jasig.maven:maven-notice-plugin` → `notice-maven-plugin` in the top-level POM and `resource-server-webapp/pom.xml`. The old artifact (`1.1.0`) depends on `javax.xml.bind.JAXBException`, which was removed from the JDK in Java 9+; it fails on Java 11 with `NoClassDefFoundError: javax/xml/bind/JAXBException`. The renamed artifact inherits v2.0.0 from `uportal-portlet-parent` and works on Java 11.
- Regenerated `NOTICE` files (parent + 5 submodule `NOTICE` files) via `mvn notice:generate`.
- Applied `mvn license:format` pass — updates to `resource-server-api/src/main/binding/bindings.xjb` and `resource-server-webapp/minify.js` license headers.

This is the `chore: pre-release prep` commit referenced in the new `RELEASE.md` (added in #320). With this merged, the `mvn release:prepare` → `release:perform` flow is expected to run cleanly on Java 11.

## Test plan

- [x] `mvn notice:generate` — passes on all 7 modules
- [x] `mvn notice:check` — passes
- [x] `mvn license:format` — passes
- [ ] Merge, pull locally, re-run `mvn release:prepare`

## Context

Follow-up to #320 (Central Publisher Portal migration). Discovered during the first `release:prepare` attempt: the `verify` phase runs `notice:check`, which invoked the broken 1.1.0 plugin and aborted the release.