### PR TITLE
chore: exclude node/ and node_modules/ from license:format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,15 @@
             <exclude>**/src/test/resources/skin-test1/jquery.hoverIntent.bom.js</exclude>
             <exclude>.idea/**</exclude>  <!-- for intelliJ Idea -->
             <exclude>overlays/**</exclude>  <!-- for intelliJ Idea -->
+            <!--
+              | frontend-maven-plugin installs a Node binary and its bundled npm
+              | into resource-server-webapp/node/. Applying a license header there
+              | breaks shebangs (e.g. npm-cli.js), causing `npm install` to fail
+              | with 'SyntaxError: Invalid or unexpected token'. Node.js only
+              | recognizes a shebang when it is literally the first line.
+            +-->
+            <exclude>**/node/**</exclude>
+            <exclude>**/node_modules/**</exclude>
           </excludes>
           <mapping>
             <tld>XML_STYLE</tld>


### PR DESCRIPTION
## Summary

Prevent `mvn license:format` from corrupting the Node runtime that `frontend-maven-plugin` installs into `resource-server-webapp/node/`.

## The bug

`license:format` has no default exclusion for the `node/` or `node_modules/` trees. When it runs, it prepends an Apache license header comment to every `.js` file it finds — including `resource-server-webapp/node/node_modules/npm/bin/npm-cli.js`. That pushes the shebang `#!/usr/bin/env node` off line 1, and Node.js only accepts a shebang on line 1. The next `npm install` invocation (triggered by `frontend:npm`) then fails:

```
npm-cli.js:19
#!/usr/bin/env node
^

SyntaxError: Invalid or unexpected token
```

Which in turn aborts `mvn clean install` and any release attempt.

## The fix

Add `**/node/**` and `**/node_modules/**` to the `license-maven-plugin` `<excludes>` in the top-level `pom.xml`, matching the pattern already used for `.idea/**` and `overlays/**`.

## Test plan

- [x] `rm -rf resource-server-webapp/node resource-server-webapp/node_modules` (clean up corrupted install)
- [x] `mvn clean install` — BUILD SUCCESS on Java 11
- [x] Confirm `license:format` no longer walks the installed Node tree: `find resource-server-webapp/node -name '*.js' -exec head -1 {} \; | grep -c '^#!'` returns a non-zero count (shebangs intact)

## Context

Follow-up to the release-prep work in #320 and #321. Surfaced while running `mvn clean install` locally during release:prepare verification.