### PR TITLE
fix: add developers block to satisfy Central Portal validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,19 @@
     <tag>HEAD</tag>
   </scm>
 
+  <!--
+    | Required by the Central Publisher Portal; without it, the 'manual
+    | upload' step returns HTTP 400 with 'Developers information is missing'
+    | for every submodule. Inherited by child modules via standard POM
+    | inheritance. Matches the pattern uPortal uses in its build.gradle.
+  +-->
+  <developers>
+    <developer>
+      <organization>uPortal Developers</organization>
+      <organizationUrl>https://github.com/uPortal-Project/resource-server/graphs/contributors</organizationUrl>
+    </developer>
+  </developers>
+
   <modules>
     <module>resource-server-api</module>
     <module>resource-server-content</module>


### PR DESCRIPTION
## Summary

Add a `<developers>` block to the top-level POM so Central Publisher Portal validation passes. Without it, every submodule POM fails validation with `Developers information is missing` on upload.

## What happened

During the 1.5.1 release attempt, `mvn release:prepare` and `release:perform` succeeded, artifacts were signed with GPG (key `73B71777CA7F628A`), and the staging upload went through authentication. The manual portal upload step then returned:

```
HTTP 400
{"error":"Failed to process request: Deployment reached an unexpected status: Failed
pkg:maven/org.jasig.resourceserver/resource-server-content@1.5.1
- Developers information is missing
pkg:maven/org.jasig.resourceserver/resource-server-api@1.5.1
- Developers information is missing
...(same for plugin, utils, core, parent)"}
```

Neither this project nor its parent `org.jasig.portlet:uportal-portlet-parent:43` declares a `<developers>` element. uPortal hit and fixed the same class of issue in its `build.gradle` during its 2026 release; this PR applies the equivalent fix here.

## The fix

```xml
<developers>
  <developer>
    <organization>uPortal Developers</organization>
    <organizationUrl>https://github.com/uPortal-Project/resource-server/graphs/contributors</organizationUrl>
  </developer>
</developers>
```

Placed in the top-level `pom.xml` right after `<scm>`. Every submodule inherits it via standard POM inheritance.

## Release plan after merge

1. Pull master
2. Re-run `mvn release:prepare && mvn release:perform` — this cuts **1.5.2** (the POM is already at `1.5.2-SNAPSHOT` from the failed 1.5.1 release-plugin's "prepare for next development iteration" commit)
3. Re-run the curl POST to `.../manual/upload/defaultRepository/org.jasig.resourceserver`
4. Review and publish in the Central Portal UI

## Housekeeping already done

- Dropped the failed 1.5.1 staging deployments in the Central Portal UI
- Deleted the `resource-server-1.5.1` tag locally and on upstream (the tagged commit lacks this fix and can't produce a valid release)

## Follow-up (separate PR, not this one)

The same `<developers>` block should be added to `org.jasig.portlet:uportal-portlet-parent`, since every portlet in the ecosystem inherits from it and will hit this same validation wall. Updating the parent avoids a per-project fix for the next 10+ portlet releases.

Also worth folding into the canonical ecosystem release doc: `uportal-project.github.io:manuals/en/uportal5-manual/developer/maven-release-process.md` should list "`<developers>` block" as a required POM element in the pre-release audit section.