### PR TITLE
chore: bump uportal-portlet-parent 43 → 46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>43</version>
+    <version>44</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -42,19 +42,6 @@
     <url>https://github.com/uPortal-Project/resource-server.git</url>
     <tag>HEAD</tag>
   </scm>
-
-  <!--
-    | Required by the Central Publisher Portal; without it, the 'manual
-    | upload' step returns HTTP 400 with 'Developers information is missing'
-    | for every submodule. Inherited by child modules via standard POM
-    | inheritance. Matches the pattern uPortal uses in its build.gradle.
-  +-->
-  <developers>
-    <developer>
-      <organization>uPortal Developers</organization>
-      <organizationUrl>https://github.com/uPortal-Project/resource-server/graphs/contributors</organizationUrl>
-    </developer>
-  </developers>
 
   <modules>
     <module>resource-server-api</module>
@@ -278,26 +265,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <!--
-    | Central Publisher Portal (OSSRH Staging API compatibility service).
-    | Shadows the stale oss.sonatype.org URLs inherited from
-    | org.sonatype.oss:oss-parent:9 (via uportal-portlet-parent). Server id
-    | 'sonatype-nexus-staging' is preserved so existing ~/.m2/settings.xml
-    | credentials keep working; the URL is what changed.
-  +-->
-  <distributionManagement>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Central Portal Release Repository</name>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
-    </repository>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Central Portal Snapshot Repository</name>
-      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <build>
     <pluginManagement>


### PR DESCRIPTION
## Summary

Consume the newly-released `uportal-portlet-parent:44`, which now provides both the `<developers>` block and the Central Portal `<distributionManagement>` we had to override locally for the 1.5.2 release. Remove the redundant per-project overrides so this project relies on the parent for both.

Next release of this project ships as **1.5.3**.

## Changes to `pom.xml`

- `<parent><version>43 → 44</version>`
- Removed the `<developers>` block (now inherited from parent v44)
- Removed the `<distributionManagement>` block (now inherited from parent v44)

## Left intentionally in place

- **`resource-server-webapp/pom.xml`'s `<distributionManagement>` override** — that module inherits from `spring-boot-starter-parent:2.7.18`, not from `resource-server-parent`, so it does not pick up the uportal-portlet-parent URLs through inheritance. Without the override it would deploy to Spring's repo.
- **`<maven.compiler.source/target>11</...>`** in the top-level properties — now redundant with parent v44's default of Java 11, but harmless. Removing it is an optional follow-up cleanup.

## Test plan

- [x] `mvn help:effective-pom -N` — BUILD SUCCESS
- [ ] After merge, pull master and run `mvn clean install` to confirm the build is still green on Java 11
- [ ] Next `mvn release:prepare && release:perform` will cut 1.5.3; the curl POST to `.../defaultRepository/org.jasig.resourceserver` should succeed with no per-project overrides required

## Context

Follows the ecosystem-wide release-prep work:
- `uPortal-Project/uportal-portlet-parent#7` — v44 prep (Central Portal URLs, Java 11 default, dropped `oss-parent:9`)
- This project's `#320`, `#321`, `#324`, `#325` — original workaround overrides that this PR now removes