### PR TITLE
chore: tighten renovate pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,51 @@
 {
-    "extends": [
-      "config:base",
-      ":rebaseStalePrs",
-      ":preserveSemverRanges"
-    ],
-    "maven": {
-      "enabled": true
+  "extends": [
+    "config:base",
+    ":rebaseStalePrs",
+    ":preserveSemverRanges"
+  ],
+  "maven": {
+    "enabled": true
+  },
+  "renovateFork": true,
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["org.springframework:"],
+      "allowedVersions": "< 6.0",
+      "description": "This library is pinned to Spring Framework 5.3.x. Spring 6+ requires Jakarta EE + Java 17+; consumers (portlets) are still on javax.servlet and Java 11."
     },
-    "renovateFork": true
+    {
+      "matchPackageNames": [
+        "com.sun.xml.bind:jaxb-impl",
+        "jakarta.xml.bind:jakarta.xml.bind-api",
+        "org.glassfish.jaxb:jaxb-runtime"
+      ],
+      "allowedVersions": "< 3.0",
+      "description": "The 2.x releases preserve the javax.xml.bind.* package namespace. 3+ moves to jakarta.xml.bind as part of Jakarta EE 9+."
+    },
+    {
+      "matchPackageNames": ["javax.servlet:javax.servlet-api"],
+      "allowedVersions": "< 5.0",
+      "description": "Servlet API 5+ is in the Jakarta EE namespace. Consumers of this library run on Tomcat 8.5/9 (Servlet 3.1) under javax.servlet."
+    },
+    {
+      "matchPackageNames": ["javax.servlet.jsp:javax.servlet.jsp-api"],
+      "allowedVersions": "< 3.0",
+      "description": "JSP API 3.x moves to the jakarta.servlet.jsp package. Consumers remain on javax."
+    },
+    {
+      "matchPackageNames": ["org.codehaus.plexus:plexus-archiver"],
+      "allowedVersions": "< 4.10.0",
+      "description": "plexus-archiver 4.10+ requires a newer commons-io than the one bundled with maven-war-plugin 3.4.0."
+    },
+    {
+      "matchPackageNames": [
+        "org.mockito:mockito-core",
+        "org.mockito:mockito-inline",
+        "org.mockito:mockito-junit-jupiter"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "Mockito 5 uses the inline MockMaker by default; its bundled byte-buddy references ClassFileVersion.JAVA_V21. Stay on Mockito 4.x until byte-buddy can be reconciled."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Add Spring/servlet-api/jsp-api/jaxb/plexus-archiver/mockito pins to renovate.json. This is a library (not a portlet WAR), so there's no portlet-api pin. Pins Spring < 6.0 (library is on 5.3.39), servlet-api < 5.0 and jsp-api < 3.0 to stay in the javax namespace for portlet consumers on Tomcat 8.5/9.

Same pattern we've applied across the portlet fleet (AnnouncementsPortlet, basiclti-portlet, BookmarksPortlet, CalendarPortlet, FeedbackPortlet, JasigWidgetPortlets, NewsReaderPortlet, SimpleContentPortlet, WebproxyPortlet): match by `matchPackagePrefixes` where possible, cap major versions at the line that requires Jakarta EE / Java 17 / Spring migrations the fleet hasn't done yet.

Once merged, Renovate will auto-close any open proposals that violate the new pins on its next rebase cycle. Dependabot proposals are not affected by `renovate.json` and need manual closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)