### PR TITLE
chore: bump uportal-portlet-parent 44 → 48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>44</version>
+    <version>48</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -53,9 +53,6 @@
   </modules>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-
     <jaxb2basicsVersion>0.13.1</jaxb2basicsVersion>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <jaxb-impl.version>2.3.3</jaxb-impl.version>
@@ -64,11 +61,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>1.3.12</version>
-      </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
@@ -90,11 +82,6 @@
         <version>2.16.1</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
-      </dependency>
-      <dependency>
         <groupId>javax.servlet.jsp</groupId>
         <artifactId>javax.servlet.jsp-api</artifactId>
         <version>2.3.3</version>
@@ -106,12 +93,6 @@
         <version>1.2</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>3.1.0</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>${jaxb-api.version}</version>
@@ -120,26 +101,6 @@
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
         <version>${jaxb-impl.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>2.0.17</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
-        <version>2.0.17</version>
-      </dependency>
-      <dependency>
-        <groupId>net.sf.ehcache</groupId>
-        <artifactId>ehcache-core</artifactId>
-        <version>2.6.11</version>
       </dependency>
       <dependency>
         <groupId>net.sf.ehcache</groupId>
@@ -244,11 +205,6 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>taglibs</groupId>
-        <artifactId>standard</artifactId>
-        <version>1.1.2</version>
-      </dependency>
-      <dependency>
         <groupId>xmlunit</groupId>
         <artifactId>xmlunit</artifactId>
         <version>1.6</version>
@@ -309,14 +265,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.1.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.scm</groupId>
-              <artifactId>maven-scm-provider-gitexe</artifactId>
-              <version>2.1.0</version>
-            </dependency>
-          </dependencies>
           <configuration>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <localCheckout>true</localCheckout>
@@ -358,7 +306,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.10.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
## Summary

- Bump `<parent>` from `uportal-portlet-parent:44` → `:48`, aligning resource-server with the rest of the actively-maintained portlet fleet.
- Drop the dependencyManagement / property / plugin-version entries now provided (or matched) by parent v48 — net `+1 / -54` lines, single file.
- No effective version change for descendants: every entry removed here is inherited back at the same or newer version from parent v48.

## Why

resource-server has been on parent v44 while every other actively-maintained portlet sits on v48. Recent parent releases brought in:

- v45 — `spring-data.version` property
- v46 — relaxed slf4j-bridge enforcer bans (so portlets on Spring 4.x can use `jcl-over-slf4j` without violating the bannedDependencies rule)
- v47 — dedup sweep, promoting common dM/plugin entries identified in ≥5 portlets
- v48 — logback `1.3.12 → 1.5.32`

The v47 sweep is what makes the cleanup worthwhile here.

## Removed (now inherited from parent v48)

| Entry | Parent version |
|---|---|
| `commons-lang:commons-lang` | 2.6 (same — promoted in v47) |
| `taglibs:standard` | 1.1.2 (same — promoted in v47) |
| `junit:junit` | 4.13.2 (same) |
| `org.slf4j:slf4j-api` | 2.0.17 (same) |
| `org.slf4j:jul-to-slf4j` | 2.0.17 (same — promoted in v47) |
| `net.sf.ehcache:ehcache-core` | 2.6.11 (same — promoted in v47) |
| `ch.qos.logback:logback-classic` | 1.5.32 (was 1.3.12 here; inherits v48 bump) |
| `javax.servlet:javax.servlet-api` | 3.1.0 (same, `provided`) |
| `maven.compiler.source/target=11` properties | parent sets these |
| `maven-release-plugin` `<version>3.1.1</version>` | parent matches via `${maven.release.plugin.ver}` |
| `maven-javadoc-plugin` `<version>3.10.0</version>` | parent has 3.11.2 in pluginManagement |

## Kept (intentionally diverge from parent)

- `springVersion=5.3.39` and the `org.springframework:*` dM entries (parent's `spring-framework-bom` is 5.3.28)
- `mockito-core:5.23.0` — parent stays on 4.9.0; v47 explicitly did not promote mockito because the fleet's mockito versions are heterogeneous
- `maven-checkstyle-plugin:3.5.0` in `<reporting>` — newer than parent's 3.3.0; the open Renovate PR #331 proposes 3.6.0
- The `<reportPlugins>` `maven-javadoc-plugin` `<version>3.10.0</version>` inside the `maven-site-plugin` configuration — that's a different resolution mechanism than `pluginManagement` and was left alone

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` on Java 11 (11.0.30-amzn) — all 7 modules build and tests pass
- [x] No new transitive version skew introduced (every removed pin is matched or superseded by parent v48)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)