### PR TITLE
chore: bump parent to v49 and inherit license-plugin defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>48</version>
+    <version>49</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -278,29 +278,29 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <basedir>${basedir}</basedir>
-          <header>${jasig-short-license-url}</header>
-          <aggregate>true</aggregate>
-          <excludes>
-            <exclude>LICENSE</exclude>
-            <exclude>NOTICE</exclude>
-            <exclude>**/src/main/webapp/rs/**</exclude>
+          <!--
+            | Parent v49 provides basedir, header URL, aggregate=true, and
+            | the standard excludes (LICENSE, NOTICE, .idea/**, overlays/**,
+            | **/src/main/webapp/rs/**) plus the <tld> mapping. Local block
+            | keeps only resource-server-specific excludes.
+            |
+            | combine.children="append" ensures the parent's <excludes>
+            | list merges with our additions instead of being replaced.
+            | Without it the parent's **/src/main/webapp/rs/** is dropped
+            | and ~6500 vendored frontend assets fail license:check.
+            |
+            | **/node/**, **/node_modules/**: frontend-maven-plugin installs
+            | a Node binary and its bundled npm into resource-server-webapp/
+            | node/. Applying a license header there breaks shebangs (e.g.
+            | npm-cli.js), causing `npm install` to fail with 'SyntaxError:
+            | Invalid or unexpected token'. Node.js only recognizes a shebang
+            | when it is literally the first line.
+          +-->
+          <excludes combine.children="append">
             <exclude>**/src/test/resources/skin-test1/jquery.hoverIntent.bom.js</exclude>
-            <exclude>.idea/**</exclude>  <!-- for intelliJ Idea -->
-            <exclude>overlays/**</exclude>  <!-- for intelliJ Idea -->
-            <!--
-              | frontend-maven-plugin installs a Node binary and its bundled npm
-              | into resource-server-webapp/node/. Applying a license header there
-              | breaks shebangs (e.g. npm-cli.js), causing `npm install` to fail
-              | with 'SyntaxError: Invalid or unexpected token'. Node.js only
-              | recognizes a shebang when it is literally the first line.
-            +-->
             <exclude>**/node/**</exclude>
             <exclude>**/node_modules/**</exclude>
           </excludes>
-          <mapping>
-            <tld>XML_STYLE</tld>
-          </mapping>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Summary

Bumps to parent v49 and shrinks the local `license-maven-plugin` block to just the resource-server-specific excludes. Required `combine.children="append"` to keep parent's `**/src/main/webapp/rs/**` exclude active — without it Maven replaces parent's `<excludes>` list with the child's, and ~6500 vendored frontend assets in `resource-server-content/src/main/webapp/rs/` fail `license:check`.

Part of the post-v49 fleet sweep.

## Changes

`pom.xml`:
- Parent `48` → `49`.
- Drop redundant `<basedir>`, `<header>`, `<aggregate>`, the 4 standard excludes (`LICENSE`, `NOTICE`, `.idea/**`, `overlays/**`), and the `<tld>` mapping — all in parent v49.
- Keep the 3 resource-server-specific excludes:
  - `**/src/test/resources/skin-test1/jquery.hoverIntent.bom.js` (BOM-marked file used as a deliberate test fixture)
  - `**/node/**` + `**/node_modules/**` (frontend-maven-plugin's bundled Node binary — adding a header to `npm-cli.js` breaks its shebang)
- Add `combine.children="append"` to `<excludes>` so parent's list merges with ours instead of being replaced.


## Why `combine.children="append"`

Maven's default merge behavior for a child plugin's `<excludes>` list is to **replace** the parent's, not append. mycila's built-in default excludes (`LICENSE`, `NOTICE`, `README`, etc.) cover most common cases, which is why the simpler shrink PRs across the fleet didn't need this — but `**/src/main/webapp/rs/**` is *not* a built-in default. resource-server has thousands of files under `rs/` paths, so the missed exclude was noisy and obvious. Worth flagging as the right pattern for future portlet sweeps that add to (rather than replace) parent's excludes.

## Test plan

- [x] `mvn clean install -DskipTests -Dgpg.skip=true` — green
- [x] `mvn license:check` — green (verified parent's `rs/**` exclude active)
- [ ] CI on Java 11 matrix
- [ ] After merge: re-verify `license:check` on master so we know the merge behavior survives across the build
